### PR TITLE
Add modal and icon behavior when saving a favorite trail using mock data/endpoints

### DIFF
--- a/client/src/TrailDetailsSideIconMenu.jsx
+++ b/client/src/TrailDetailsSideIconMenu.jsx
@@ -1,34 +1,117 @@
-import React from "react";
-import Typography from "@mui/material/Typography";
-import { IconButton } from "@mui/material";
-import DirectionsOutlinedIcon from "@mui/icons-material/DirectionsOutlined";
-import BookmarkBorderOutlinedIcon from "@mui/icons-material/BookmarkBorderOutlined";
-import ReadMoreOutlinedIcon from "@mui/icons-material/ReadMoreOutlined";
+import React from 'react';
+import Typography from '@mui/material/Typography';
+import { IconButton } from '@mui/material';
+import DirectionsOutlinedIcon from '@mui/icons-material/DirectionsOutlined';
+import BookmarkBorderOutlinedIcon from '@mui/icons-material/BookmarkBorderOutlined';
+import ReadMoreOutlinedIcon from '@mui/icons-material/ReadMoreOutlined';
+import Modal from '@mui/material/Modal';
+import Box from '@mui/material/Box';
+import Button from '@mui/material/Button';
+import MuiAlert from '@mui/material/Alert';
+import BookmarkAddedIcon from '@mui/icons-material/BookmarkAdded';
 
-export default function TrailDetailsSideIconMenu({ trail }) {
+const style = {
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: 400,
+  bgcolor: 'background.paper',
+  border: '2px solid #000',
+  boxShadow: 24,
+  p: 4,
+};
+
+const Alert = React.forwardRef(function Alert(props, ref) {
+  return <MuiAlert elevation={6} ref={ref} variant='filled' {...props} />;
+});
+
+export default function TrailDetailsSideIconMenu({
+  trail,
+  showAlert,
+  successType,
+  hasMatch
+}) {
+  const [open, setOpen] = React.useState(false);
+  const [filled, showFilled] = React.useState(false);
+  const handleOpen = () => setOpen(true);
+  const handleClose = () => setOpen(false);
+
+  const saveTrail = () => {
+    const faveTrail = {
+      id: trail.id,
+      name: trail.name,
+    };
+    showFilled(true);
+    fetch('/saveFavoriteTrail', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(faveTrail),
+    })
+      .then(() => {
+        handleClose();
+        showAlert();
+        successType(true);
+      })
+      .catch((err) => {
+        successType(false);
+        showFilled(false);
+        console.log('err on save favorite trails', err);
+      });
+  };
+
   return (
     <>
-      <div className="button-wrapper">
-        {/* TODO: add functionality to save this to a user list */}
-        <IconButton className="details-banner-button">
-          <BookmarkBorderOutlinedIcon></BookmarkBorderOutlinedIcon>
-          <Typography className="details-icons-text">Save</Typography>
+      <div className='button-wrapper'>
+        <IconButton className='details-banner-button' onClick={handleOpen}>
+          {(filled || hasMatch) ? (
+            <BookmarkAddedIcon></BookmarkAddedIcon>
+          ) : (
+            <BookmarkBorderOutlinedIcon></BookmarkBorderOutlinedIcon>
+          )}
+          <Typography className='details-icons-text'>Save</Typography>
         </IconButton>
+        <Modal open={open} onClose={handleClose}>
+          <Box sx={style}>
+            <Typography id='modal-modal-title' variant='h6' component='h2'>
+              Save as a favorite trail?
+            </Typography>
+            <Typography id='modal-modal-description' sx={{ mt: 2 }}>
+              You'll be able to find this under your saved trails.
+            </Typography>
+            <div className='modal-button-wrapper'>
+              <Button
+                variant='contained'
+                onClick={saveTrail}
+                sx={{ marginRight: '1rem' }}
+              >
+                Save
+              </Button>
+              <Button variant='outlined' onClick={handleClose}>
+                Cancel
+              </Button>
+            </div>
+          </Box>
+        </Modal>
         <IconButton
-          className="details-banner-button"
+          className='details-banner-button'
           onClick={() => {
-            window.open(`${trail.url}`, "_blank");
+            window.open(`${trail.url}`, '_blank');
           }}
         >
           <ReadMoreOutlinedIcon></ReadMoreOutlinedIcon>
-          <Typography className="details-icons-text">More</Typography>
+          <Typography className='details-icons-text'>More</Typography>
         </IconButton>
-        {/* TODO: add functionality to open google maps with long/lat */}
-        <IconButton className="details-banner-button" onClick={()=>{window.open(trail.googleMapsURL, '_blank')}}>
+        <IconButton
+          className='details-banner-button'
+          onClick={() => {
+            window.open(trail.googleMapsURL, '_blank');
+          }}
+        >
           <DirectionsOutlinedIcon></DirectionsOutlinedIcon>
-          <Typography className="details-icons-text">
-          Directions
-            </Typography>
+          <Typography className='details-icons-text'>Directions</Typography>
         </IconButton>
       </div>
     </>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -160,3 +160,9 @@
   color: #B5DEF4;
   padding-top: 12px;
 }
+
+.modal-button-wrapper {
+  display: flex;
+  margin-top: 1rem;
+  justify-content: flex-end;
+}

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -6,6 +6,7 @@ export default defineConfig({
   server: {
     proxy: {
       '/api': 'http://localhost:4000/',
+      '/getAllFavoriteTrails': 'http://localhost:4000/',
     }
   },
   plugins: [react()],

--- a/server/mock/mockFavoriteTrails.json
+++ b/server/mock/mockFavoriteTrails.json
@@ -1,0 +1,16 @@
+{
+  "data": [
+    {
+      "id": 288895,
+      "name": "Bear Creek Regional Park"
+    },
+    {
+      "id": 288891,
+      "name": "Garden of the Gods: Ute Trail"
+    },
+    {
+      "id": 286836,
+      "name": "Red Rock Canyon"
+    }
+  ]
+}

--- a/server/server.js
+++ b/server/server.js
@@ -8,6 +8,21 @@ app.use(express.json());
 app.use('/api/trails', bikeTrailsRouter);
 app.use('/api/moreInfo', bikeTrailInfoRouter);
 
+// NEEDED FOR UI MOCK - REMOVE LATER
+const fs = require('fs');
+const path = require('path');
+const mockTrailsFilePath = path.join(__dirname, 'mock/mockFavoriteTrails.json');
+
+// MOCK ENDPOINT FOR UI DEVELOPMENT - REMOVE LATER
+app.post('/saveFavoriteTrail', (req, res) => {
+  res.sendStatus(200);
+}); 
+// MOCK ENDPOINT FOR UI DEVELOPMENT - REMOVE LATER
+app.get('/getAllFavoriteTrails', (req, res) => {
+  const readable = fs.createReadStream(mockTrailsFilePath);
+  readable.pipe(res);
+});
+
 app.get('/googlecallback', (req, res) => {
   return res.redirect('http://localhost:5173');
 })


### PR DESCRIPTION
## Overview

## Issue Type
- [X] Feature

## Description
Shows saved bookmark if /getAllFavoriteTrails GET endpoint includes the trail id that matches the trail clicked for the detail page
Shows saved bookmark if /saveFavoriteTrail POST is successful
Created mock data and endpoints to unblock UI work while SVC completes these endpoints
Displays success/failure alert upon saving a trail as a favorite

## Screenshots & Videos

<img width="210" alt="Screen Shot 2023-04-11 at 10 58 30 PM" src="https://user-images.githubusercontent.com/49803818/231354126-70ec8245-a920-4620-8f89-9d3c58859a21.png">
<img width="453" alt="Screen Shot 2023-04-11 at 10 59 24 PM" src="https://user-images.githubusercontent.com/49803818/231354296-ab32b202-50ff-4571-a1da-a4b422c46f75.png">

## Additional context
Delete/reverse logic of save/POST will follow in a separate PR.
