### PR TITLE
Fix paper height on home screen to fix spinner layover height

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -89,7 +89,7 @@ const App = () => {
             path="/"
             element={
               <>
-                <Paper sx={{ height: '30rem' }}>
+                <Paper sx={{ height: '100%' }}>
                   <div className="container">
                     <div className="img-wrapper">
                       <img

--- a/client/src/TrailDetailsSideIconMenu.jsx
+++ b/client/src/TrailDetailsSideIconMenu.jsx
@@ -7,7 +7,6 @@ import ReadMoreOutlinedIcon from "@mui/icons-material/ReadMoreOutlined";
 import Modal from "@mui/material/Modal";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
-import MuiAlert from "@mui/material/Alert";
 import BookmarkAddedIcon from "@mui/icons-material/BookmarkAdded";
 
 const style = {
@@ -21,7 +20,6 @@ const style = {
   boxShadow: 24,
   p: 4,
 };
-
 
 export default function TrailDetailsSideIconMenu({
   trail,


### PR DESCRIPTION
## Overview

Issue Type

- [x] Bug

Description
Adjust height of MUI Paper so that the LoadingOverlay background has an appropriate height 
Ticket Item

